### PR TITLE
#6, #7, #8: Application endpoints created

### DIFF
--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -15,6 +15,8 @@ from app.models.tenant_user import TenantUser
 from app.models.user import User
 
 if TYPE_CHECKING:
+    from app.repositories.application_repository import ApplicationRepository
+    from app.services.application_service import ApplicationService
     from app.services.auth_services import AuthService
 
 bearer_scheme = HTTPBearer(auto_error=False)
@@ -45,6 +47,22 @@ async def get_auth_service(
     from app.services.auth_services import AuthService
 
     return AuthService(db=db, redis_client=redis_client)
+
+
+async def get_application_repository(
+    db: AsyncSession = Depends(get_db),
+) -> "ApplicationRepository":
+    from app.repositories.application_repository import ApplicationRepository
+
+    return ApplicationRepository(session=db)
+
+
+async def get_application_service(
+    repository: "ApplicationRepository" = Depends(get_application_repository),
+) -> "ApplicationService":
+    from app.services.application_service import ApplicationService
+
+    return ApplicationService(repository=repository)
 
 
 async def get_current_user(

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,6 +1,8 @@
 from fastapi import APIRouter
 
+from app.api.routes.applications import router as applications_router
 from app.api.routes.auth import router as auth_router
 
 api_router = APIRouter(prefix="/api")
 api_router.include_router(auth_router)
+api_router.include_router(applications_router)

--- a/backend/app/api/routes/applications.py
+++ b/backend/app/api/routes/applications.py
@@ -1,0 +1,88 @@
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.api.deps import get_application_service, get_current_tenant
+from app.models.application import ApplicationStatus
+from app.models.tenant import Tenant
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationListParams,
+    ApplicationResponse,
+    ApplicationUpdate,
+)
+
+router = APIRouter(prefix="/applications", tags=["applications"])
+
+
+@router.post(
+    "", response_model=ApplicationResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_application(
+    payload: ApplicationCreate,
+    tenant: Tenant = Depends(get_current_tenant),
+    service: Any = Depends(get_application_service),
+) -> ApplicationResponse:
+    return await service.create_application(tenant.id, payload)
+
+
+@router.get("/{application_id}", response_model=ApplicationResponse)
+async def get_application_by_id(
+    application_id: UUID,
+    tenant: Tenant = Depends(get_current_tenant),
+    service: Any = Depends(get_application_service),
+) -> ApplicationResponse:
+    application = await service.get_application_by_id(tenant.id, application_id)
+    if application is None:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return application
+
+
+@router.get("", response_model=list[ApplicationResponse])
+async def list_applications(
+    tenant: Tenant = Depends(get_current_tenant),
+    service: Any = Depends(get_application_service),
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    status_filter: ApplicationStatus | None = Query(default=None, alias="status"),
+    company: str | None = Query(default=None),
+    sort_by: Literal["applied_date", "created_at", "company", "status"] = Query(
+        default="created_at"
+    ),
+    sort_order: Literal["asc", "desc"] = Query(default="desc"),
+) -> list[ApplicationResponse]:
+    params = ApplicationListParams(
+        limit=limit,
+        offset=offset,
+        status=status_filter,
+        company=company,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+    return await service.list_applications(tenant.id, params)
+
+
+@router.patch("/{application_id}", response_model=ApplicationResponse)
+async def update_application(
+    application_id: UUID,
+    payload: ApplicationUpdate,
+    tenant: Tenant = Depends(get_current_tenant),
+    service: Any = Depends(get_application_service),
+) -> ApplicationResponse:
+    updated = await service.update_application(tenant.id, application_id, payload)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return updated
+
+
+@router.delete("/{application_id}", response_model=ApplicationResponse)
+async def soft_delete_application(
+    application_id: UUID,
+    tenant: Tenant = Depends(get_current_tenant),
+    service: Any = Depends(get_application_service),
+) -> ApplicationResponse:
+    deleted = await service.soft_delete_application(tenant.id, application_id)
+    if deleted is None:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return deleted

--- a/backend/app/repositories/application_repository.py
+++ b/backend/app/repositories/application_repository.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timezone
+from uuid import UUID
+
+from sqlalchemy import asc, desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Select
+
+from app.models.application import Application, ApplicationStatus
+
+
+class ApplicationRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    def _base_query(self, tenant_id: UUID) -> Select[tuple[Application]]:
+        return select(Application).where(
+            Application.tenant_id == tenant_id,
+            Application.deleted_at.is_(None),
+        )
+
+    async def create_application(self, data: dict) -> Application:
+        application = Application(**data)
+        self.session.add(application)
+        await self.session.commit()
+        await self.session.refresh(application)
+        return application
+
+    async def get_application_by_id(
+        self, tenant_id: UUID, application_id: UUID
+    ) -> Application | None:
+        query = self._base_query(tenant_id).where(Application.id == application_id)
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def list_applications(
+        self,
+        tenant_id: UUID,
+        limit: int,
+        offset: int,
+        status: ApplicationStatus | None = None,
+        company: str | None = None,
+        sort_by: str = "created_at",
+        sort_order: str = "desc",
+    ) -> list[Application]:
+        query = self._base_query(tenant_id)
+
+        if status is not None:
+            query = query.where(Application.status == status)
+
+        if company is not None:
+            query = query.where(Application.company.ilike(f"%{company.strip()}%"))
+
+        allowed_sort_fields = {
+            "applied_date": Application.applied_date,
+            "created_at": Application.created_at,
+            "company": Application.company,
+            "status": Application.status,
+        }
+        sort_column = allowed_sort_fields.get(sort_by, Application.created_at)
+        sort_direction = asc if sort_order.lower() == "asc" else desc
+        query = query.order_by(sort_direction(sort_column))
+
+        query = query.limit(limit).offset(offset)
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def update_application(
+        self, tenant_id: UUID, application_id: UUID, updates: dict
+    ) -> Application | None:
+        application = await self.get_application_by_id(tenant_id, application_id)
+        if application is None:
+            return None
+
+        for field, value in updates.items():
+            if hasattr(application, field):
+                setattr(application, field, value)
+
+        await self.session.commit()
+        await self.session.refresh(application)
+        return application
+
+    async def soft_delete_application(
+        self, tenant_id: UUID, application_id: UUID
+    ) -> Application | None:
+        application = await self.get_application_by_id(tenant_id, application_id)
+        if application is None:
+            return None
+
+        application.deleted_at = datetime.now(timezone.utc)
+        await self.session.commit()
+        await self.session.refresh(application)
+        return application

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -1,0 +1,66 @@
+from datetime import date, datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import ConfigDict, Field, model_validator
+
+from app.models.application import ApplicationStatus
+from app.schemas.clean_input_model import CleanInputModel
+
+
+class ApplicationCreate(CleanInputModel):
+    title: str = Field(min_length=1, max_length=200)
+    company: str = Field(min_length=1, max_length=200)
+    location: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    salary_range: str | None = Field(default=None, max_length=100)
+    notes: str | None = None
+    url: str | None = Field(default=None, max_length=500)
+    applied_date: date
+    status: ApplicationStatus | None = None
+
+
+class ApplicationUpdate(CleanInputModel):
+    title: str | None = Field(default=None, min_length=1, max_length=200)
+    company: str | None = Field(default=None, min_length=1, max_length=200)
+    location: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    salary_range: str | None = Field(default=None, max_length=100)
+    notes: str | None = None
+    url: str | None = Field(default=None, max_length=500)
+    applied_date: date | None = None
+    status: ApplicationStatus | None = None
+
+    @model_validator(mode="after")
+    def validate_at_least_one_field(self) -> "ApplicationUpdate":
+        if not self.model_fields_set:
+            raise ValueError("At least one field must be provided for update")
+        return self
+
+
+class ApplicationListParams(CleanInputModel):
+    limit: int = Field(default=20, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)
+    status: ApplicationStatus | None = None
+    company: str | None = Field(default=None, min_length=1, max_length=200)
+    sort_by: Literal["applied_date", "created_at", "company", "status"] = "created_at"
+    sort_order: Literal["asc", "desc"] = "desc"
+
+
+class ApplicationResponse(CleanInputModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    tenant_id: UUID
+    title: str
+    company: str
+    status: ApplicationStatus
+    location: str
+    description: str | None
+    salary_range: str | None
+    notes: str | None
+    url: str | None
+    applied_date: date
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None

--- a/backend/app/services/application_service.py
+++ b/backend/app/services/application_service.py
@@ -1,0 +1,55 @@
+from uuid import UUID
+
+from app.models.application import Application
+from app.repositories.application_repository import ApplicationRepository
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationListParams,
+    ApplicationUpdate,
+)
+
+
+class ApplicationService:
+    def __init__(self, repository: ApplicationRepository):
+        self.repository = repository
+
+    async def create_application(
+        self, tenant_id: UUID, payload: ApplicationCreate
+    ) -> Application:
+        data = payload.model_dump(exclude_none=True)
+        data["tenant_id"] = tenant_id
+        return await self.repository.create_application(data)
+
+    async def get_application_by_id(
+        self, tenant_id: UUID, application_id: UUID
+    ) -> Application | None:
+        return await self.repository.get_application_by_id(tenant_id, application_id)
+
+    async def list_applications(
+        self, tenant_id: UUID, params: ApplicationListParams
+    ) -> list[Application]:
+        return await self.repository.list_applications(
+            tenant_id=tenant_id,
+            limit=params.limit,
+            offset=params.offset,
+            status=params.status,
+            company=params.company,
+            sort_by=params.sort_by,
+            sort_order=params.sort_order,
+        )
+
+    async def update_application(
+        self,
+        tenant_id: UUID,
+        application_id: UUID,
+        payload: ApplicationUpdate,
+    ) -> Application | None:
+        updates = payload.model_dump(exclude_unset=True)
+        return await self.repository.update_application(
+            tenant_id, application_id, updates
+        )
+
+    async def soft_delete_application(
+        self, tenant_id: UUID, application_id: UUID
+    ) -> Application | None:
+        return await self.repository.soft_delete_application(tenant_id, application_id)

--- a/backend/tests/test_api_deps.py
+++ b/backend/tests/test_api_deps.py
@@ -78,6 +78,32 @@ async def test_get_auth_service_returns_auth_service(deps_module):
 
 
 @pytest.mark.asyncio
+async def test_get_application_repository_returns_repository(deps_module):
+    repository_module = importlib.import_module(
+        "app.repositories.application_repository"
+    )
+    repository_module = importlib.reload(repository_module)
+
+    fake_db = object()
+    repository = await deps_module.get_application_repository(db=fake_db)
+
+    assert isinstance(repository, repository_module.ApplicationRepository)
+    assert repository.session is fake_db
+
+
+@pytest.mark.asyncio
+async def test_get_application_service_returns_application_service(deps_module):
+    service_module = importlib.import_module("app.services.application_service")
+    service_module = importlib.reload(service_module)
+
+    fake_repository = object()
+    service = await deps_module.get_application_service(repository=fake_repository)
+
+    assert isinstance(service, service_module.ApplicationService)
+    assert service.repository is fake_repository
+
+
+@pytest.mark.asyncio
 async def test_get_current_user_raises_without_credentials(deps_module):
     db = AsyncMock()
 

--- a/backend/tests/test_api_router.py
+++ b/backend/tests/test_api_router.py
@@ -8,6 +8,8 @@ def test_api_router_contains_auth_endpoints():
     route_paths = {route.path for route in api_router.routes}
     assert "/api/auth/signup" in route_paths
     assert "/api/auth/login" in route_paths
+    assert "/api/applications" in route_paths
+    assert "/api/applications/{application_id}" in route_paths
 
 
 def test_main_app_exposes_auth_endpoints():
@@ -16,3 +18,5 @@ def test_main_app_exposes_auth_endpoints():
 
     assert "/api/auth/signup" in route_paths
     assert "/api/auth/login" in route_paths
+    assert "/api/applications" in route_paths
+    assert "/api/applications/{application_id}" in route_paths

--- a/backend/tests/test_application_repository.py
+++ b/backend/tests/test_application_repository.py
@@ -1,0 +1,211 @@
+from datetime import date
+
+import pytest
+from sqlalchemy import select
+
+from app.models.application import Application, ApplicationStatus
+from app.models.tenant import Tenant
+from app.repositories.application_repository import ApplicationRepository
+
+
+async def _create_tenant(db_session, name: str) -> Tenant:
+    tenant = Tenant(name=name)
+    db_session.add(tenant)
+    await db_session.flush()
+    return tenant
+
+
+@pytest.mark.asyncio
+async def test_create_application_returns_persisted_model(db_session):
+    tenant = await _create_tenant(db_session, "CreateRepoTenant")
+    repo = ApplicationRepository(db_session)
+
+    created = await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Backend Engineer",
+            "company": "Contoso",
+            "location": "Remote",
+            "applied_date": date(2026, 2, 20),
+        }
+    )
+
+    assert created.id is not None
+    assert created.status == ApplicationStatus.applied
+
+    stored = await db_session.scalar(
+        select(Application).where(Application.id == created.id)
+    )
+    assert stored is not None
+
+
+@pytest.mark.asyncio
+async def test_get_application_by_id_is_tenant_scoped_and_returns_none(db_session):
+    tenant = await _create_tenant(db_session, "TenantA")
+    another_tenant = await _create_tenant(db_session, "TenantB")
+    repo = ApplicationRepository(db_session)
+
+    app_obj = await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "SDE",
+            "company": "Northwind",
+            "location": "Hybrid",
+            "applied_date": date(2026, 2, 19),
+        }
+    )
+
+    found = await repo.get_application_by_id(tenant.id, app_obj.id)
+    not_found = await repo.get_application_by_id(another_tenant.id, app_obj.id)
+
+    assert found is not None
+    assert not_found is None
+
+
+@pytest.mark.asyncio
+async def test_list_applications_supports_filters_pagination_and_sorting(db_session):
+    tenant = await _create_tenant(db_session, "ListTenant")
+    another_tenant = await _create_tenant(db_session, "ListTenantOther")
+    repo = ApplicationRepository(db_session)
+
+    await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Role 1",
+            "company": "Acme",
+            "status": ApplicationStatus.applied,
+            "location": "Remote",
+            "applied_date": date(2026, 2, 1),
+        }
+    )
+    await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Role 2",
+            "company": "Acme Labs",
+            "status": ApplicationStatus.screening,
+            "location": "Remote",
+            "applied_date": date(2026, 2, 2),
+        }
+    )
+    await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Role 3",
+            "company": "Globex",
+            "status": ApplicationStatus.screening,
+            "location": "Remote",
+            "applied_date": date(2026, 2, 3),
+        }
+    )
+    await repo.create_application(
+        {
+            "tenant_id": another_tenant.id,
+            "title": "Other Tenant Role",
+            "company": "Acme",
+            "status": ApplicationStatus.screening,
+            "location": "Onsite",
+            "applied_date": date(2026, 2, 4),
+        }
+    )
+
+    filtered = await repo.list_applications(
+        tenant_id=tenant.id,
+        limit=10,
+        offset=0,
+        status=ApplicationStatus.screening,
+        company="acme",
+        sort_by="applied_date",
+        sort_order="asc",
+    )
+
+    assert len(filtered) == 1
+    assert filtered[0].title == "Role 2"
+
+    paged = await repo.list_applications(
+        tenant_id=tenant.id,
+        limit=1,
+        offset=1,
+        sort_by="applied_date",
+        sort_order="asc",
+    )
+    assert len(paged) == 1
+    assert paged[0].title == "Role 2"
+
+    safe_sort = await repo.list_applications(
+        tenant_id=tenant.id,
+        limit=10,
+        offset=0,
+        sort_by="not_allowed",
+        sort_order="asc",
+    )
+    assert len(safe_sort) == 3
+
+
+@pytest.mark.asyncio
+async def test_update_application_applies_updates_and_returns_none_when_missing(
+    db_session,
+):
+    tenant = await _create_tenant(db_session, "UpdateTenant")
+    another_tenant = await _create_tenant(db_session, "UpdateTenantOther")
+    repo = ApplicationRepository(db_session)
+
+    app_obj = await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Original Title",
+            "company": "Original Co",
+            "location": "Remote",
+            "applied_date": date(2026, 2, 10),
+        }
+    )
+
+    updated = await repo.update_application(
+        tenant.id,
+        app_obj.id,
+        {
+            "title": "Updated Title",
+            "status": ApplicationStatus.interview,
+        },
+    )
+
+    assert updated is not None
+    assert updated.title == "Updated Title"
+    assert updated.status == ApplicationStatus.interview
+
+    missing = await repo.update_application(
+        another_tenant.id,
+        app_obj.id,
+        {"title": "Should Not Update"},
+    )
+    assert missing is None
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_marks_record_and_hides_from_base_queries(db_session):
+    tenant = await _create_tenant(db_session, "SoftDeleteTenant")
+    repo = ApplicationRepository(db_session)
+
+    app_obj = await repo.create_application(
+        {
+            "tenant_id": tenant.id,
+            "title": "Delete Me",
+            "company": "Delete Co",
+            "location": "Remote",
+            "applied_date": date(2026, 2, 11),
+        }
+    )
+
+    deleted = await repo.soft_delete_application(tenant.id, app_obj.id)
+    assert deleted is not None
+    assert deleted.deleted_at is not None
+
+    found_after_delete = await repo.get_application_by_id(tenant.id, app_obj.id)
+    listed_after_delete = await repo.list_applications(
+        tenant_id=tenant.id,
+        limit=10,
+        offset=0,
+    )
+
+    assert found_after_delete is None
+    assert all(application.id != app_obj.id for application in listed_after_delete)

--- a/backend/tests/test_application_routes.py
+++ b/backend/tests/test_application_routes.py
@@ -1,0 +1,77 @@
+import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_application_service, get_current_tenant
+from app.api.routes.applications import router as applications_router
+
+
+def _build_test_client(fake_service, tenant_id: uuid.UUID):
+    app = FastAPI()
+    app.include_router(applications_router)
+    app.dependency_overrides[get_application_service] = lambda: fake_service
+    app.dependency_overrides[get_current_tenant] = lambda: type(
+        "TenantObj", (), {"id": tenant_id}
+    )()
+    return TestClient(app)
+
+
+def _application_response(application_id: uuid.UUID, tenant_id: uuid.UUID) -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "id": str(application_id),
+        "tenant_id": str(tenant_id),
+        "title": "Backend Engineer",
+        "company": "Contoso",
+        "status": "applied",
+        "location": "Remote",
+        "description": None,
+        "salary_range": None,
+        "notes": None,
+        "url": None,
+        "applied_date": str(date(2026, 2, 24)),
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+        "deleted_at": None,
+    }
+
+
+def test_create_application_route_calls_service_and_returns_payload():
+    fake_service = AsyncMock()
+    tenant_id = uuid.uuid4()
+    application_id = uuid.uuid4()
+    fake_service.create_application.return_value = _application_response(
+        application_id, tenant_id
+    )
+
+    client = _build_test_client(fake_service, tenant_id)
+
+    response = client.post(
+        "/applications",
+        json={
+            "title": "Backend Engineer",
+            "company": "Contoso",
+            "location": "Remote",
+            "applied_date": "2026-02-24",
+            "status": "applied",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["id"] == str(application_id)
+    fake_service.create_application.assert_awaited_once()
+
+
+def test_get_application_by_id_returns_404_when_service_returns_none():
+    fake_service = AsyncMock()
+    tenant_id = uuid.uuid4()
+    fake_service.get_application_by_id.return_value = None
+    client = _build_test_client(fake_service, tenant_id)
+
+    response = client.get(f"/applications/{uuid.uuid4()}")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Application not found"

--- a/backend/tests/test_application_schema.py
+++ b/backend/tests/test_application_schema.py
@@ -1,0 +1,67 @@
+from datetime import date
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.application import ApplicationStatus
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationListParams,
+    ApplicationUpdate,
+)
+
+
+def test_application_create_parses_status_enum_and_forbids_extra_fields():
+    obj = ApplicationCreate(
+        title="Software Engineer",
+        company="Contoso",
+        location="Remote",
+        applied_date=date(2026, 2, 24),
+        status="screening",
+    )
+
+    assert obj.status == ApplicationStatus.screening
+
+    with pytest.raises(ValidationError):
+        ApplicationCreate(
+            title="Software Engineer",
+            company="Contoso",
+            location="Remote",
+            applied_date=date(2026, 2, 24),
+            unknown_field="x",
+        )
+
+
+def test_application_update_requires_at_least_one_field():
+    with pytest.raises(ValidationError):
+        ApplicationUpdate()
+
+
+@pytest.mark.parametrize(
+    "sort_by,sort_order",
+    [
+        ("applied_date", "asc"),
+        ("created_at", "desc"),
+        ("company", "asc"),
+        ("status", "desc"),
+    ],
+)
+def test_application_list_params_accept_only_whitelisted_sort(sort_by, sort_order):
+    params = ApplicationListParams(sort_by=sort_by, sort_order=sort_order)
+
+    assert params.sort_by == sort_by
+    assert params.sort_order == sort_order
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"sort_by": "title"},
+        {"sort_order": "up"},
+        {"limit": 0},
+        {"offset": -1},
+    ],
+)
+def test_application_list_params_reject_invalid_values(payload):
+    with pytest.raises(ValidationError):
+        ApplicationListParams(**payload)

--- a/backend/tests/test_application_service.py
+++ b/backend/tests/test_application_service.py
@@ -1,0 +1,84 @@
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.application import ApplicationStatus
+from app.schemas.application import (
+    ApplicationCreate,
+    ApplicationListParams,
+    ApplicationUpdate,
+)
+from app.services.application_service import ApplicationService
+
+
+@pytest.mark.asyncio
+async def test_create_application_adds_tenant_id_and_calls_repository():
+    repository = AsyncMock()
+    repository.create_application = AsyncMock(return_value={"id": uuid.uuid4()})
+    service = ApplicationService(repository=repository)
+
+    tenant_id = uuid.uuid4()
+    payload = ApplicationCreate(
+        title="Backend Engineer",
+        company="Contoso",
+        location="Remote",
+        applied_date=date(2026, 2, 24),
+        status="screening",
+    )
+
+    await service.create_application(tenant_id, payload)
+
+    repository.create_application.assert_awaited_once()
+    data = repository.create_application.await_args.args[0]
+    assert data["tenant_id"] == tenant_id
+    assert data["status"] == ApplicationStatus.screening
+
+
+@pytest.mark.asyncio
+async def test_list_applications_passes_validated_params_to_repository():
+    repository = AsyncMock()
+    repository.list_applications = AsyncMock(return_value=[])
+    service = ApplicationService(repository=repository)
+
+    tenant_id = uuid.uuid4()
+    params = ApplicationListParams(
+        limit=10,
+        offset=5,
+        status="interview",
+        company="Acme",
+        sort_by="applied_date",
+        sort_order="asc",
+    )
+
+    await service.list_applications(tenant_id, params)
+
+    repository.list_applications.assert_awaited_once_with(
+        tenant_id=tenant_id,
+        limit=10,
+        offset=5,
+        status=ApplicationStatus.interview,
+        company="Acme",
+        sort_by="applied_date",
+        sort_order="asc",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_application_uses_dynamic_update_payload():
+    repository = AsyncMock()
+    repository.update_application = AsyncMock(return_value={"id": uuid.uuid4()})
+    service = ApplicationService(repository=repository)
+
+    tenant_id = uuid.uuid4()
+    application_id = uuid.uuid4()
+    payload = ApplicationUpdate(status="offer", notes="Strong fit")
+
+    await service.update_application(tenant_id, application_id, payload)
+
+    repository.update_application.assert_awaited_once_with(
+        tenant_id,
+        application_id,
+        {"status": ApplicationStatus.offer, "notes": "Strong fit"},
+    )


### PR DESCRIPTION
Added the application API endpoints with related service and repository layers by covering the following path:
- Created application_repository
- Tenant-scoped queries
- CRUD operations
- Pagination logic
- Business logic separation
- Validation schemas
- Status enum handling
- Update logic

The following endpoints are created:
- POST /applications
- GET /applications/{id}
- GET /applications (paginated + filtered)
- PUT /applications/{id}
- DELETE /applications/{id}

